### PR TITLE
[MIG] Migrate to Odoo 12. Refactor Date compute and formatting

### DIFF
--- a/Chapter05/ch05_r08_computed/models/library_book.py
+++ b/Chapter05/ch05_r08_computed/models/library_book.py
@@ -21,21 +21,20 @@ class LibraryBook(models.Model):
 
     @api.depends('date_release')
     def _compute_age(self):
-        today = fDate.from_string(fDate.context_today(self))
+        today = fDate.context_today(self)
         for book in self.filtered('date_release'):
-            delta = (today - fDate.from_string(book.date_release))
+            delta = today - book.date_release
             book.age_days = delta.days
 
     def _inverse_age(self):
-        today = fDate.from_string(fDate.context_today(self))
+        today = fDate.context_today(self)
         for book in self.filtered('date_release'):
-            d = today - timedelta(days=book.age_days)
-            book.date_release = fDate.to_string(d)
+            d = fDate.subtract(today, days=book.age_days)
+            book.date_release = d
 
     def _search_age(self, operator, value):
-        today = fDate.from_string(fDate.context_today(self))
-        value_days = timedelta(days=value)
-        value_date = fDate.to_string(today - value_days)
+        today = fDate.context_today(self)
+        value_date = fDate.subtract(today, days=value)
         # convert the operator:
         # book with age > value have a date < value_date
         operator_map = {


### PR DESCRIPTION
There no need for Date formatting to make date computing. In Odoo 12
Date and Datetime fields are proper Python date and datetime objects.

References:
* https://www.odoo.com/es_ES/groups/technical-62/technical-56392463
* https://github.com/odoo/odoo/commit/960360afe478a8f7b9c456721b5591154952a37d
* https://www.odoo.com/documentation/master/reference/orm.html#date-and-datetime-fields